### PR TITLE
Add stub controllers and services

### DIFF
--- a/esadad-java/README_java.md
+++ b/esadad-java/README_java.md
@@ -1,0 +1,17 @@
+# Java Spring Boot Version
+
+This directory contains a basic Spring Boot project that mirrors the original C# controllers. It exposes endpoints for bill pull, prepaid validation and payment notifications. Each endpoint returns a simple response object.
+
+Build with Maven (Java 11):
+
+```bash
+mvn package
+```
+
+Run the application:
+
+```bash
+mvn spring-boot:run
+```
+
+These commands may require Maven to be installed in your environment.

--- a/esadad-java/pom.xml
+++ b/esadad-java/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.esadad</groupId>
+    <artifactId>esadad-java</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.17</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>11</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/esadad-java/src/main/java/com/esadad/EsadadJavaApplication.java
+++ b/esadad-java/src/main/java/com/esadad/EsadadJavaApplication.java
@@ -1,0 +1,11 @@
+package com.esadad;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EsadadJavaApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(EsadadJavaApplication.class, args);
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/api/PaymentController.java
+++ b/esadad-java/src/main/java/com/esadad/api/PaymentController.java
@@ -1,0 +1,26 @@
+package com.esadad.api;
+
+import com.esadad.model.PaymentNotificationResponse;
+import com.esadad.service.PaymentNotificationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/payment")
+public class PaymentController {
+
+    private final PaymentNotificationService paymentNotificationService;
+
+    @Autowired
+    public PaymentController(PaymentNotificationService paymentNotificationService) {
+        this.paymentNotificationService = paymentNotificationService;
+    }
+
+    @PostMapping("/ReceivePaymentNotification")
+    public PaymentNotificationResponse receivePaymentNotification(@RequestParam("GUID") String guid,
+                                                                  @RequestBody String xmlElement,
+                                                                  @RequestParam(value = "username", required = false) String username,
+                                                                  @RequestParam(value = "password", required = false) String password) {
+        return paymentNotificationService.handleNotification(guid, xmlElement);
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/api/PostPaidController.java
+++ b/esadad-java/src/main/java/com/esadad/api/PostPaidController.java
@@ -1,0 +1,26 @@
+package com.esadad.api;
+
+import com.esadad.model.BillPullResponse;
+import com.esadad.service.BillPullService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/postpaid")
+public class PostPaidController {
+
+    private final BillPullService billPullService;
+
+    @Autowired
+    public PostPaidController(BillPullService billPullService) {
+        this.billPullService = billPullService;
+    }
+
+    @PostMapping("/BillPull")
+    public BillPullResponse billPull(@RequestParam("GUID") String guid,
+                                     @RequestBody String xmlElement,
+                                     @RequestParam(value = "username", required = false) String username,
+                                     @RequestParam(value = "password", required = false) String password) {
+        return billPullService.billPull(guid, xmlElement);
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/api/PrepaidController.java
+++ b/esadad-java/src/main/java/com/esadad/api/PrepaidController.java
@@ -1,0 +1,26 @@
+package com.esadad.api;
+
+import com.esadad.model.PrePaidResponse;
+import com.esadad.service.PrepaidValidationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/prepaid")
+public class PrepaidController {
+
+    private final PrepaidValidationService prepaidValidationService;
+
+    @Autowired
+    public PrepaidController(PrepaidValidationService prepaidValidationService) {
+        this.prepaidValidationService = prepaidValidationService;
+    }
+
+    @PostMapping("/PrepaidValidation")
+    public PrePaidResponse prepaidValidation(@RequestParam("GUID") String guid,
+                                             @RequestBody String xmlElement,
+                                             @RequestParam(value = "username", required = false) String username,
+                                             @RequestParam(value = "password", required = false) String password) {
+        return prepaidValidationService.validate(guid, xmlElement);
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/model/BillPullResponse.java
+++ b/esadad-java/src/main/java/com/esadad/model/BillPullResponse.java
@@ -1,0 +1,22 @@
+package com.esadad.model;
+
+public class BillPullResponse {
+    private String guid;
+    private String message;
+
+    public String getGuid() {
+        return guid;
+    }
+
+    public void setGuid(String guid) {
+        this.guid = guid;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/model/PaymentNotificationResponse.java
+++ b/esadad-java/src/main/java/com/esadad/model/PaymentNotificationResponse.java
@@ -1,0 +1,22 @@
+package com.esadad.model;
+
+public class PaymentNotificationResponse {
+    private String guid;
+    private String message;
+
+    public String getGuid() {
+        return guid;
+    }
+
+    public void setGuid(String guid) {
+        this.guid = guid;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/model/PrePaidResponse.java
+++ b/esadad-java/src/main/java/com/esadad/model/PrePaidResponse.java
@@ -1,0 +1,22 @@
+package com.esadad.model;
+
+public class PrePaidResponse {
+    private String guid;
+    private String status;
+
+    public String getGuid() {
+        return guid;
+    }
+
+    public void setGuid(String guid) {
+        this.guid = guid;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/service/BillPullService.java
+++ b/esadad-java/src/main/java/com/esadad/service/BillPullService.java
@@ -1,0 +1,7 @@
+package com.esadad.service;
+
+import com.esadad.model.BillPullResponse;
+
+public interface BillPullService {
+    BillPullResponse billPull(String guid, String xmlElement);
+}

--- a/esadad-java/src/main/java/com/esadad/service/PaymentNotificationService.java
+++ b/esadad-java/src/main/java/com/esadad/service/PaymentNotificationService.java
@@ -1,0 +1,7 @@
+package com.esadad.service;
+
+import com.esadad.model.PaymentNotificationResponse;
+
+public interface PaymentNotificationService {
+    PaymentNotificationResponse handleNotification(String guid, String xmlElement);
+}

--- a/esadad-java/src/main/java/com/esadad/service/PrepaidValidationService.java
+++ b/esadad-java/src/main/java/com/esadad/service/PrepaidValidationService.java
@@ -1,0 +1,7 @@
+package com.esadad.service;
+
+import com.esadad.model.PrePaidResponse;
+
+public interface PrepaidValidationService {
+    PrePaidResponse validate(String guid, String xmlElement);
+}

--- a/esadad-java/src/main/java/com/esadad/service/impl/BillPullServiceImpl.java
+++ b/esadad-java/src/main/java/com/esadad/service/impl/BillPullServiceImpl.java
@@ -1,0 +1,16 @@
+package com.esadad.service.impl;
+
+import com.esadad.model.BillPullResponse;
+import com.esadad.service.BillPullService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BillPullServiceImpl implements BillPullService {
+    @Override
+    public BillPullResponse billPull(String guid, String xmlElement) {
+        BillPullResponse response = new BillPullResponse();
+        response.setGuid(guid);
+        response.setMessage("Bill pulled");
+        return response;
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/service/impl/PaymentNotificationServiceImpl.java
+++ b/esadad-java/src/main/java/com/esadad/service/impl/PaymentNotificationServiceImpl.java
@@ -1,0 +1,16 @@
+package com.esadad.service.impl;
+
+import com.esadad.model.PaymentNotificationResponse;
+import com.esadad.service.PaymentNotificationService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentNotificationServiceImpl implements PaymentNotificationService {
+    @Override
+    public PaymentNotificationResponse handleNotification(String guid, String xmlElement) {
+        PaymentNotificationResponse response = new PaymentNotificationResponse();
+        response.setGuid(guid);
+        response.setMessage("Received");
+        return response;
+    }
+}

--- a/esadad-java/src/main/java/com/esadad/service/impl/PrepaidValidationServiceImpl.java
+++ b/esadad-java/src/main/java/com/esadad/service/impl/PrepaidValidationServiceImpl.java
@@ -1,0 +1,16 @@
+package com.esadad.service.impl;
+
+import com.esadad.model.PrePaidResponse;
+import com.esadad.service.PrepaidValidationService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PrepaidValidationServiceImpl implements PrepaidValidationService {
+    @Override
+    public PrePaidResponse validate(String guid, String xmlElement) {
+        PrePaidResponse response = new PrePaidResponse();
+        response.setGuid(guid);
+        response.setStatus("Validated");
+        return response;
+    }
+}


### PR DESCRIPTION
## Summary
- extend Java code with PostPaid and Prepaid controllers
- include simple service interfaces and implementations for bill pull and prepaid validation
- provide basic response models
- update Java README with build and run instructions

## Testing
- `mvn -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e3160612c83219eb75b022bc24b32